### PR TITLE
Made the 'no-js' class get removed when the page loads

### DIFF
--- a/source/_scripts.erb
+++ b/source/_scripts.erb
@@ -56,6 +56,8 @@ function toggleClass(el, className) {
 	}
 }
 
+toggleClass(document.querySelector('html'), 'no-js');
+
 </script>
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Using the existing `toggleClass` function from `source/_scripts.erb`. Fixes #19
