### PR TITLE
Added code example to Battery Status API

### DIFF
--- a/source/browserapis/batterystatus.html.md
+++ b/source/browserapis/batterystatus.html.md
@@ -19,10 +19,40 @@ links_examples:
 suggested_uses:
   - Involved content, such as video viewing or gaming, to alert user of low battery.
   - Also returns whether charging - possibilities there
+notes:
+  - The value 'Infinity' for chargingTime means either the device is currently discharging or the system was unable to report the value.
+  - The value 'Infinity' for dischargingTime means either the device is currently charging or the system was unable to report the value.
 ---
 
 
 ```js
-// just write code here
+if("getBattery" in navigator) {
+  navigator.getBattery().then(function(battery) {
+
+    console.log("Is battery charging? " + (battery.charging ? "Yes" : "No"));
+    console.log("Battery level: " + battery.level * 100 + "%");
+    console.log("Time until battery charged: " + battery.chargingTime + " seconds");
+    console.log("Time until batter discharged: " + battery.dischargingTime + " seconds");
+
+    battery.addEventListener('chargingchange', function() {
+      console.log("Is battery charging? " + (battery.charging ? "Yes" : "No"));
+    });
+
+    battery.addEventListener('levelchange', function() {
+      console.log("Battery level: " + battery.level * 100 + "%");
+    });
+
+    battery.addEventListener('chargingtimechange', function() {
+      console.log("Time until battery charged: " + battery.chargingTime + " seconds");
+    });
+
+    battery.addEventListener('dischargingtimechange', function() {
+      console.log("Time until batter discharged: " + battery.dischargingTime + " seconds");
+    });
+
+  });
+} else {
+  console.log("Sorry, Battery Status API is not supported on this device.");
+}
 
 ```

--- a/source/browserapis/batterystatus.html.md
+++ b/source/browserapis/batterystatus.html.md
@@ -19,9 +19,6 @@ links_examples:
 suggested_uses:
   - Involved content, such as video viewing or gaming, to alert user of low battery.
   - Also returns whether charging - possibilities there
-notes:
-  - The value 'Infinity' for chargingTime means either the device is currently discharging or the system was unable to report the value.
-  - The value 'Infinity' for dischargingTime means either the device is currently charging or the system was unable to report the value.
 ---
 
 
@@ -56,3 +53,5 @@ if("getBattery" in navigator) {
 }
 
 ```
+- The value `Infinity` for `chargingTime` means either the device is currently discharging or the system was unable to report the value.
+- The value `Infinity` for `dischargingTime` means either the device is currently charging or the system was unable to report the value.


### PR DESCRIPTION
Fixes #46

Makes use of #58 to add a note about `charginTime` and `dischargingTime` returning `Infinity`. 

This will still work fine without #58 being merged, it just wont show the note.
