### PR TITLE
add web platform link missing from matchMedia

### DIFF
--- a/source/browserapis/matchmedia.html.md
+++ b/source/browserapis/matchmedia.html.md
@@ -7,6 +7,7 @@ w3c_status: W3C Recommendation (Dec '13)
 w3c_link: http://www.w3.org/TR/cssom-view/#dom-window-matchmedia
 caniuse: http://caniuse.com/#feat=matchmedia
 mdn_docs: https://developer.mozilla.org/en/docs/Web/API/Window/matchMedia
+web_platform: https://docs.webplatform.org/wiki/css/media_queries/apis/matchMedia
 
 links_tutsarts:
   'matchMedia is cooler than you think' : http://wilsonpage.co.uk/matchmedia-is-cooler-than-you-think/


### PR DESCRIPTION
Hey

I noticed I missed this off from a pull request merged at the beginning of the month

Thanks

Jonathan
