### PR TITLE
Explain that you may need sudo to install bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ use these commands to setup Middleman.
 
 ```
 # Install Bundler and the Middleman dependencies
+# (You may need to prefix this command with sudo...)
 gem install bundler
 bundle install
 # Run the Middleman server, watching for any changes


### PR DESCRIPTION
I do all development in Docker so I have a vanilla OS X system outside of
that. I don't do much ruby development but when I ran 'gem install bundler' it
said I needed sudo. Is this expected? If so, maybe this patch to the docs will
help. Without mentioning it, someone may think they are doing something wrong
because requiring sudo usually means you're doing something wrong ;)
